### PR TITLE
Ad singlewindow

### DIFF
--- a/v0.1/reference_submissions/anomaly_detection/api/submitter_implemented.h
+++ b/v0.1/reference_submissions/anomaly_detection/api/submitter_implemented.h
@@ -41,7 +41,7 @@ methods from th_libc.h and all testharness methods from th_lib.h are here.
 #define EE_MSG_TIMESTAMP "m-lap-us-%lu\r\n"
 #define TH_VENDOR_NAME_STRING "unspecified"
 
-#define MAX_DB_INPUT_SIZE (200 * 128 * 4 * 2)  // full histogram: 200 slices, 128 freq bins, float32
+#define MAX_DB_INPUT_SIZE (5 * 128 * 4 * 2)  // histogram window: 5 slices, 128 freq bins, float32
 #define TH_MODEL_VERSION EE_MODEL_VERSION_DCASE01
 
 #include <stdarg.h>

--- a/v0.1/reference_submissions/anomaly_detection/micro_model_settings.h
+++ b/v0.1/reference_submissions/anomaly_detection/micro_model_settings.h
@@ -23,7 +23,7 @@ const int kFeatureSliceCount = 5;
 const int kFeatureElementCount = (kFeatureSliceSize * kFeatureSliceCount);
 
 const int kSpectrogramSliceCount = 200;
-const int kInputSize = (kFeatureSliceSize * kSpectrogramSliceCount);
-const int kFeatureWindows = kSpectrogramSliceCount - kFeatureSliceCount + 1;    // 200 - 5 + 1
+const int kInputSize = (kFeatureSliceSize * kFeatureSliceCount);
+//const int kFeatureWindows = kSpectrogramSliceCount - kFeatureSliceCount + 1;    // 200 - 5 + 1
 
 #endif  // TENSORFLOW_LITE_MICRO_EXAMPLES_ANOMALY_DETECTION_MICRO_FEATURES_MICRO_MODEL_SETTINGS_H_

--- a/v0.1/reference_submissions/anomaly_detection/submitter_implemented.cpp
+++ b/v0.1/reference_submissions/anomaly_detection/submitter_implemented.cpp
@@ -48,7 +48,7 @@ in th_results is copied from the original in EEMBC.
 #include "micro_model_settings.h"
 
 UnbufferedSerial pc(USBTX, USBRX);
-DigitalOut g_timestampPin(D7)
+DigitalOut g_timestampPin(D7);
 
 constexpr int kTensorArenaSize = 10 * 1024;
 uint8_t tensor_arena[kTensorArenaSize];

--- a/v0.1/reference_submissions/anomaly_detection/submitter_implemented.cpp
+++ b/v0.1/reference_submissions/anomaly_detection/submitter_implemented.cpp
@@ -193,7 +193,7 @@ void th_final_initialize(void) {
   if ((model_input->dims->size != 2) || (model_input->dims->data[0] != 1) ||
       (model_input->dims->data[1] !=
        (kFeatureSliceCount * kFeatureSliceSize)) ||
-      (model_input->type != kTfLiteFloat32)) {
+      (model_input->type != kTfLiteInt8)) {
     TF_LITE_REPORT_ERROR(error_reporter,
                          "Bad input tensor parameters in model");
     return;

--- a/v0.1/reference_submissions/anomaly_detection/submitter_implemented.cpp
+++ b/v0.1/reference_submissions/anomaly_detection/submitter_implemented.cpp
@@ -249,7 +249,7 @@ void th_serialport_initialize(void) {
 #if EE_CFG_ENERGY_MODE == 1
        pc.baud(9600);
 #else
-       pc.baud(115200);
+       pc.baud(921600);
 #endif
 }
 

--- a/v0.1/training/anomaly_detection/common.py
+++ b/v0.1/training/anomaly_detection/common.py
@@ -141,7 +141,8 @@ def file_to_vector_array(file_name,
                          method="librosa",
                          save_png=False,
                          save_hist=False,
-                         save_bin=False):
+                         save_bin=False,
+                         save_parts=False):
     """
     convert file_name to a vector array.
 
@@ -207,6 +208,13 @@ def file_to_vector_array(file_name,
         save_path = file_name.replace('.wav', '_hist_' + method + '.bin')
         # transpose to obtain correct order
         numpy.swapaxes(log_mel_spectrogram, 0, 1).astype('float32').tofile(save_path)
+
+    # 08 (optional) save parts (sliding window)
+    if save_parts:
+        for i in range(vector_array_size):
+            save_path = file_name.replace('.wav', '_hist_' + method + '_part{0:03d}'.format(i) + '.bin')
+            # transpose to obtain correct order?
+            vector_array[i].astype('float32').tofile(save_path)
 
     return vector_array
 


### PR DESCRIPTION
Change evaluation to run per histogram window, instead of looping through the full histogram.
This reduces memory requirements, eliminates the loop, and thus reduces memory copying during the measured time.