### PR TITLE
cleanup #defines & add comments

### DIFF
--- a/v0.1/api/internally_implemented.h
+++ b/v0.1/api/internally_implemented.h
@@ -39,7 +39,7 @@ The file name has been changed and some functions removed.
 /* Version 1.0 of the benchmark only supports these models */
 #define EE_MODEL_VERSION_KWS01 "kws01"
 #define EE_MODEL_VERSION_VWW01 "vww01"
-#define EE_MODEL_VERSION_DCASE01 "ad01"
+#define EE_MODEL_VERSION_AD01 "ad01"
 #define EE_MODEL_VERSION_IC01 "ic01"
 
 typedef enum { EE_ARG_CLAIMED, EE_ARG_UNCLAIMED } arg_claimed_t;

--- a/v0.1/api/submitter_implemented.h
+++ b/v0.1/api/submitter_implemented.h
@@ -37,14 +37,29 @@ methods from th_libc.h and all testharness methods from th_lib.h are here.
 /// \brief These defines set logging prefixes for test harness integration.
 /// \detail This API is designed for performance evaluation only. In order to
 /// gather energy measurments we recommend using the EEMBC test suite.
-#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
 #define EE_MSG_TIMESTAMP "m-lap-us-%lu\r\n"
 #define TH_VENDOR_NAME_STRING "unspecified"
 
 #define MAX_DB_INPUT_SIZE (96 * 96 * 3)
-#define TH_MODEL_VERSION EE_MODEL_VERSION_VWW01
+#ifndef TH_MODEL_VERSION
+// See "internally_implemented.h" for a list
+#error "PLease set TH_MODEL_VERSION to one of the EE_MODEL_VERSION_* defines"
+// e.g.: to inform the user of model `ic01` use this:
+// #define TH_MODEL_VERSION EE_MODEL_VERSION_IC01
+#endif
 
+// Use this to switch between DUT-direct (perf) & DUT-inderrect (energy) modes
+#ifndef EE_CFG_ENERGY_MODE
 #define EE_CFG_ENERGY_MODE 0
+#endif
+
+// This is a visual cue to the user when reviewing logs or plugging an
+// unknown device into the system.
+#if EE_CFG_ENERGY_MODE == 1
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
+#else
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-performance\r\n"
+#endif
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/v0.1/reference_submissions/anomaly_detection/README.md
+++ b/v0.1/reference_submissions/anomaly_detection/README.md
@@ -14,3 +14,6 @@ Compile using Mbed CLI tools
 Deploy on Nucleo board
 
     cp ./BUILD/NUCLEO_L4R5ZI/GCC_ARM/anomaly_detection.bin /Volumes/NODE_L4R5ZI/
+
+
+NOTE: This reference code uses a performance-mode baud rate of 921600 instead of 115200, which requires changing the `~/.eembc.ini` file setting in order to use the DUT. Please see the benchmark runner GitHub readme for information on changing the runner's default baud rate.

--- a/v0.1/reference_submissions/anomaly_detection/api/submitter_implemented.h
+++ b/v0.1/reference_submissions/anomaly_detection/api/submitter_implemented.h
@@ -37,12 +37,24 @@ methods from th_libc.h and all testharness methods from th_lib.h are here.
 /// \brief These defines set logging prefixes for test harness integration.
 /// \detail This API is designed for performance evaluation only. In order to
 /// gather energy measurments we recommend using the EEMBC test suite.
-#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
 #define EE_MSG_TIMESTAMP "m-lap-us-%lu\r\n"
 #define TH_VENDOR_NAME_STRING "unspecified"
 
 #define MAX_DB_INPUT_SIZE (5 * 128 * 4 * 2)  // histogram window: 5 slices, 128 freq bins, float32
-#define TH_MODEL_VERSION EE_MODEL_VERSION_DCASE01
+#define TH_MODEL_VERSION EE_MODEL_VERSION_AD01
+
+// Use this to switch between DUT-direct (perf) & DUT-inderrect (energy) modes
+#ifndef EE_CFG_ENERGY_MODE
+#define EE_CFG_ENERGY_MODE 0
+#endif
+
+// This is a visual cue to the user when reviewing logs or plugging an
+// unknown device into the system.
+#if EE_CFG_ENERGY_MODE == 1
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
+#else
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-performance\r\n"
+#endif
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/v0.1/reference_submissions/image_classification/api/internally_implemented.h
+++ b/v0.1/reference_submissions/image_classification/api/internally_implemented.h
@@ -39,8 +39,7 @@ The file name has been changed and some functions removed.
 /* Version 1.0 of the benchmark only supports these models */
 #define EE_MODEL_VERSION_KWS01 "kws01"
 #define EE_MODEL_VERSION_VWW01 "vww01"
-#define EE_MODEL_VERSION_DCASE01 "dcase01"
-#define EE_MODEL_VERSION_RN801 "rn801"
+#define EE_MODEL_VERSION_AD01 "ad01"
 #define EE_MODEL_VERSION_IC01 "ic01"
 
 typedef enum { EE_ARG_CLAIMED, EE_ARG_UNCLAIMED } arg_claimed_t;

--- a/v0.1/reference_submissions/image_classification/api/submitter_implemented.h
+++ b/v0.1/reference_submissions/image_classification/api/submitter_implemented.h
@@ -37,12 +37,24 @@ methods from th_libc.h and all testharness methods from th_lib.h are here.
 /// \brief These defines set logging prefixes for test harness integration.
 /// \detail This API is designed for performance evaluation only. In order to
 /// gather energy measurments we recommend using the EEMBC test suite.
-#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
 #define EE_MSG_TIMESTAMP "m-lap-us-%lu\r\n"
 #define TH_VENDOR_NAME_STRING "unspecified"
 
 #define MAX_DB_INPUT_SIZE (32 * 32 * 3)
 #define TH_MODEL_VERSION EE_MODEL_VERSION_IC01
+
+// Use this to switch between DUT-direct (perf) & DUT-inderrect (energy) modes
+#ifndef EE_CFG_ENERGY_MODE
+#define EE_CFG_ENERGY_MODE 0
+#endif
+
+// This is a visual cue to the user when reviewing logs or plugging an
+// unknown device into the system.
+#if EE_CFG_ENERGY_MODE == 1
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
+#else
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-performance\r\n"
+#endif
 
 #include <stdarg.h>
 #include <stdio.h>

--- a/v0.1/reference_submissions/person_detection/api/submitter_implemented.h
+++ b/v0.1/reference_submissions/person_detection/api/submitter_implemented.h
@@ -37,14 +37,24 @@ methods from th_libc.h and all testharness methods from th_lib.h are here.
 /// \brief These defines set logging prefixes for test harness integration.
 /// \detail This API is designed for performance evaluation only. In order to
 /// gather energy measurments we recommend using the EEMBC test suite.
-#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
 #define EE_MSG_TIMESTAMP "m-lap-us-%lu\r\n"
 #define TH_VENDOR_NAME_STRING "unspecified"
 
 #define MAX_DB_INPUT_SIZE (96 * 96 * 3)
 #define TH_MODEL_VERSION EE_MODEL_VERSION_VWW01
 
+// Use this to switch between DUT-direct (perf) & DUT-inderrect (energy) modes
+#ifndef EE_CFG_ENERGY_MODE
 #define EE_CFG_ENERGY_MODE 0
+#endif
+
+// This is a visual cue to the user when reviewing logs or plugging an
+// unknown device into the system.
+#if EE_CFG_ENERGY_MODE == 1
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-energy\r\n"
+#else
+#define EE_MSG_TIMESTAMP_MODE "m-timestamp-mode-performance\r\n"
+#endif
 
 #include <stdarg.h>
 #include <stdio.h>


### PR DESCRIPTION
1. Updated 3 of 4 models to properly switch output message if EE_CFG_ENERGY_MODE is set/reset. (ad01, ic01, vww01)
2. Added comments to ad01 explaining perf mode baud is 921600
3. Switched DCASE01 to AD01 in type #def
4. Updated main api/submitter_implemented.h to generate preprocessor error if no type is defined