### PR TITLE
[API] Enable access to data buffer

### DIFF
--- a/benchmark/api/internally_implemented.cpp
+++ b/benchmark/api/internally_implemented.cpp
@@ -322,3 +322,12 @@ size_t ee_get_buffer(uint8_t* buffer, size_t max_len) {
   }
   return len;
 }
+
+/**
+ * @brief get data buffer pointer
+ * 
+ * @return a pointer to gp_buff;
+ */
+uint8_t* ee_get_buffer_pointer() {
+  return gp_buff;
+}

--- a/benchmark/api/internally_implemented.h
+++ b/benchmark/api/internally_implemented.h
@@ -56,6 +56,7 @@ void ee_benchmark_initialize(void);
 long ee_hexdec(char *);
 void ee_infer(size_t n, size_t n_warmup);
 size_t ee_get_buffer(uint8_t* buffer, size_t max_len);
+uint8_t* ee_get_buffer_pointer();
 arg_claimed_t ee_buffer_parse(char *command);
 arg_claimed_t ee_profile_parse(char *command);
 


### PR DESCRIPTION
Hi,
For microcontrollers with limited memory, we can optimize memory usage by directly passing `gp_buff` to inference machine instead of copying the data to a separate memory.
For some microcontrollers this is a huge amount of memory and it's a matter of whether the model/runtime fits on device or not. I'll be happy to change the implementation if there is any suggestion.

Thanks.