### PR TITLE
Fixed license confusion.

### DIFF
--- a/benchmark/api/internally_implemented.cpp
+++ b/benchmark/api/internally_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/api/internally_implemented.h
+++ b/benchmark/api/internally_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/api/submitter_implemented.h
+++ b/benchmark/api/submitter_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/anomaly_detection/api/submitter_implemented.h
+++ b/benchmark/reference_submissions/anomaly_detection/api/submitter_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/anomaly_detection/submitter_implemented.cpp
+++ b/benchmark/reference_submissions/anomaly_detection/submitter_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/empty_reference/submitter_implemented.cpp
+++ b/benchmark/reference_submissions/empty_reference/submitter_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/image_classification/api/internally_implemented.cpp
+++ b/benchmark/reference_submissions/image_classification/api/internally_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/image_classification/api/internally_implemented.h
+++ b/benchmark/reference_submissions/image_classification/api/internally_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/image_classification/api/submitter_implemented.h
+++ b/benchmark/reference_submissions/image_classification/api/submitter_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/image_classification/submitter_implemented.cpp
+++ b/benchmark/reference_submissions/image_classification/submitter_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/keyword_spotting/api/submitter_implemented.h
+++ b/benchmark/reference_submissions/keyword_spotting/api/submitter_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/keyword_spotting/submitter_implemented.cpp
+++ b/benchmark/reference_submissions/keyword_spotting/submitter_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/mbed_basic/submitter_implemented.cpp
+++ b/benchmark/reference_submissions/mbed_basic/submitter_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/person_detection/api/submitter_implemented.h
+++ b/benchmark/reference_submissions/person_detection/api/submitter_implemented.h
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/benchmark/reference_submissions/person_detection/submitter_implemented.cpp
+++ b/benchmark/reference_submissions/person_detection/submitter_implemented.cpp
@@ -1,15 +1,5 @@
 /*
-Copyright (C) EEMBC(R). All Rights Reserved
-
-All EEMBC Benchmark Software are products of EEMBC and are provided under the
-terms of the EEMBC Benchmark License Agreements. The EEMBC Benchmark Software
-are proprietary intellectual properties of EEMBC and its Members and is
-protected under all applicable laws, including all applicable copyright laws.
-
-If you received this EEMBC Benchmark Software without having a currently
-effective EEMBC Benchmark License Agreement, you must discontinue use.
-
-Copyright 2020 The MLPerf Authors. All Rights Reserved.
+Copyright 2020 EEMBC and The MLPerf Authors. All Rights Reserved.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
Previously there were two licenses on some files: EEMBC's
and Apache 2.0. Now there is only one license: Apache 2.0.