### PR TITLE
kws_ref_model_float32.tflite is Hybrid Model

### DIFF
--- a/benchmark/training/keyword_spotting/quantize.py
+++ b/benchmark/training/keyword_spotting/quantize.py
@@ -12,7 +12,6 @@ if __name__ == '__main__':
   print(f"Converting trained model {Flags.saved_model_path} to TFL model at {Flags.tfl_file_name}")
   model = tf.keras.models.load_model(Flags.saved_model_path)
   converter = tf.lite.TFLiteConverter.from_keras_model(model)
-  converter.optimizations = [tf.lite.Optimize.DEFAULT]
   
   fp32_tfl_file_name = Flags.tfl_file_name[:Flags.tfl_file_name.rfind('.')] + '_float32.tflite'
   tflite_float_model = converter.convert()


### PR DESCRIPTION
I removed the TFLite Optimization flag during the conversion of the Keras model to the FP32 TFLite version, which produces kws_ref_model_float32.tflite. Previously, kws_ref_model_float32.tflite was a hybrid model, featuring both INT8 and FP32 operations, which are not supported by TFLM. To align with the goals of this benchmark and the other three use cases (anomaly detection, image classification, and visual wake words), kws_ref_model_float32.tflite should use only FP32 operations. My commit ensures this.